### PR TITLE
Add Quad9 dns configuration

### DIFF
--- a/DNSecure/Presets.swift
+++ b/DNSecure/Presets.swift
@@ -65,5 +65,33 @@ enum Presets {
                 )
             )
         ),
+        .init(
+            name: "Quad9",
+            configuration: .dnsOverTLS(
+                DoTConfiguration(
+                    servers: [
+                        "9.9.9.9",
+                        "149.112.112.112",
+                        "2620:fe::fe",
+                        "2620:fe::fe:9",
+                    ],
+                    serverName: "dns.quad9.net"
+                )
+            )
+        ),
+        .init(
+            name: "Quad9",
+            configuration: .dnsOverHTTPS(
+                DoHConfiguration(
+                    servers: [
+                        "9.9.9.9",
+                        "149.112.112.112",
+                        "2620:fe::fe",
+                        "2620:fe::fe:9",
+                    ],
+                    serverURL: URL(string: "https://dns.quad9.net/dns-query")
+                )
+            )
+        ),
     ]
 }


### PR DESCRIPTION
This add another DNS service to the default list.

If you want i can make a pull request with the most used ones like, opendns and so on. Also to include cloudflare for families and other from quad9, so the user can select most of them and save him from entering a lot of information by hand.