### PR TITLE
fix: fix UUID mismatch issue (#72)

### DIFF
--- a/DNSecure/DNSecureApp.swift
+++ b/DNSecure/DNSecureApp.swift
@@ -12,8 +12,15 @@ let logger = Logger()
 
 @main
 struct DNSecureApp {
-    @AppStorage("servers") private var servers = Presets.servers
+    @AppStorage("servers") private var servers: Resolvers = []
     @AppStorage("usedID") private var usedID: String?
+
+    init() {
+        if UserDefaults.standard.object(forKey: "servers") == nil {
+            // Set the default value in order to fix UUIDs
+            self.servers = Presets.servers
+        }
+    }
 }
 
 extension DNSecureApp: App {


### PR DESCRIPTION
fixes #72

`AppStorage` doesn't store its data in `UserDefaults` until the setter is called once.